### PR TITLE
Add support for DataTables and DataFrames

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ ReadStat.jl: Read files from Stata, SPSS, and SAS
 
 The ReadStat.jl Julia module uses the
 [ReadStat](https://github.com/WizardMac/ReadStat) C library to parse binary and
-transport files from Stata, SPSS and SAS. All functions return a
-[DataFrame](https://github.com/JuliaStats/DataFrames.jl).
+transport files from Stata, SPSS and SAS. All functions return either a
+[DataFrame](https://github.com/JuliaStats/DataFrames.jl) (default) or a
+[DataTable](https://github.com/JuliaData/DataTables.jl).
 
 Usage:
 
 ```julia
-using ReadStat
+using ReadStat, DataTables, DataFrames
 
 read_dta("/path/to/something.dta")
 
@@ -22,4 +23,22 @@ read_por("/path/to/something.por")
 read_sav("/path/to/something.sav")
 
 read_sas7bdat("/path/to/something.sas7bdat")
+
+read_dta(DataTable, "/path/to/something.dta")
+
+read_por(DataTable, "/path/to/something.por")
+
+read_sav(DataTable, "/path/to/something.sav")
+
+read_sas7bdat(DataTable, "/path/to/something.sas7bdat")
+
+read_dta(DataFrame, "/path/to/something.dta")
+
+read_por(DataFrame, "/path/to/something.por")
+
+read_sav(DataFrame, "/path/to/something.sav")
+
+read_sas7bdat(DataFrame, "/path/to/something.sas7bdat")
+
+
 ```

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,7 @@
 julia 0.5
+DataArrays
 NullableArrays
 DataFrames
+DataTables
 BinDeps
 @windows WinRPM

--- a/test/read_dta.jl
+++ b/test/read_dta.jl
@@ -1,27 +1,75 @@
-using NullableArrays, Base.Test
+using DataArrays, NullableArrays, DataTables, DataFrames, Base.Test
 
 dtafile = joinpath(dirname(@__FILE__), "types.dta")
 
+# Test default return container type
+
 df = read_dta(dtafile)
-@test typeof(df[:, :vfloat]) == NullableVector{Float32}
-@test typeof(df[:, :vdouble]) == NullableVector{Float64}
-@test typeof(df[:, :vlong]) == NullableVector{Int32}
-@test typeof(df[:, :vint]) == NullableVector{Int16}
-@test typeof(df[:, :vbyte]) == NullableVector{Int8}
-@test typeof(df[:, :vstring]) == NullableVector{String}
+@test typeof(df[:, :vfloat]) == DataVector{Float32}
+@test typeof(df[:, :vdouble]) == DataVector{Float64}
+@test typeof(df[:, :vlong]) == DataVector{Int32}
+@test typeof(df[:, :vint]) == DataVector{Int16}
+@test typeof(df[:, :vbyte]) == DataVector{Int8}
+@test typeof(df[:, :vstring]) == DataVector{String}
 
-@test get(df[2, :vfloat]) == 7
-@test get(df[2, :vdouble]) == 7
-@test get(df[2, :vlong]) == 7
-@test get(df[2, :vint]) == 7
-@test get(df[2, :vbyte]) == 7
-@test get(df[2, :vstring]) == "7"
+@test df[2, :vfloat] == 7
+@test df[2, :vdouble] == 7
+@test df[2, :vlong] == 7
+@test df[2, :vint] == 7
+@test df[2, :vbyte] == 7
+@test df[2, :vstring] == "7"
 
-@test isnull(df[3, :vfloat])
-@test isnull(df[3, :vdouble])
-@test isnull(df[3, :vlong])
-@test isnull(df[3, :vint])
-@test isnull(df[3, :vbyte])
-@test get(df[3, :vstring]) == ""
+@test isna(df[3, :vfloat])
+@test isna(df[3, :vdouble])
+@test isna(df[3, :vlong])
+@test isna(df[3, :vint])
+@test isna(df[3, :vbyte])
+@test df[3, :vstring] == ""
 
+# Test explicit DataFrame return container type
 
+df = read_dta(DataFrame, dtafile)
+@test typeof(df[:, :vfloat]) == DataVector{Float32}
+@test typeof(df[:, :vdouble]) == DataVector{Float64}
+@test typeof(df[:, :vlong]) == DataVector{Int32}
+@test typeof(df[:, :vint]) == DataVector{Int16}
+@test typeof(df[:, :vbyte]) == DataVector{Int8}
+@test typeof(df[:, :vstring]) == DataVector{String}
+
+@test df[2, :vfloat] == 7
+@test df[2, :vdouble] == 7
+@test df[2, :vlong] == 7
+@test df[2, :vint] == 7
+@test df[2, :vbyte] == 7
+@test df[2, :vstring] == "7"
+
+@test isna(df[3, :vfloat])
+@test isna(df[3, :vdouble])
+@test isna(df[3, :vlong])
+@test isna(df[3, :vint])
+@test isna(df[3, :vbyte])
+@test df[3, :vstring] == ""
+
+# Test explicit DataTable return container type
+
+dt = read_dta(DataTable, dtafile)
+@test typeof(dt[:, :vfloat]) == NullableVector{Float32}
+@test typeof(dt[:, :vdouble]) == NullableVector{Float64}
+@test typeof(dt[:, :vlong]) == NullableVector{Int32}
+@test typeof(dt[:, :vint]) == NullableVector{Int16}
+@test typeof(dt[:, :vbyte]) == NullableVector{Int8}
+@test typeof(dt[:, :vstring]) == NullableVector{String}
+
+@test get(dt[2, :vfloat]) == 7
+@test get(dt[2, :vdouble]) == 7
+@test get(dt[2, :vlong]) == 7
+@test get(dt[2, :vint]) == 7
+@test get(dt[2, :vbyte]) == 7
+@test get(dt[2, :vstring]) == "7"
+
+@test isnull(dt[3, :vfloat])
+@test isnull(dt[3, :vdouble])
+@test isnull(dt[3, :vlong])
+@test isnull(dt[3, :vint])
+@test isnull(dt[3, :vbyte])
+@test get(dt[3, :vstring]) == ""


### PR DESCRIPTION
This makes things fit better into the current data storage story in julia. DataFrames now always hold DataArrays, and DataTables hold NullableArrays. With this change DataFrames are the default return value, but one can also ask for a DataTable.